### PR TITLE
Express Swagger UI on Vercel 

### DIFF
--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -1,0 +1,25 @@
+const swaggerHtml = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+    <style>body{margin:0}</style>
+  </head>
+  <body>
+    <div id="swagger"></div>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      window.ui = SwaggerUIBundle({
+        url: '/.well-known/ai-plugin.json',
+        dom_id: '#swagger',
+        deepLinking: true
+      });
+    </script>
+  </body>
+</html>`;
+
+export default function swaggerHandler(_req: any, res: any) {
+  res.setHeader("content-type", "text/html; charset=utf-8");
+  res.status(200).send(swaggerHtml);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import { pluginData } from "./plugin.js";
+import swaggerHandler from "./api/swagger.js";
 import { healthRouter } from "./api/health.js";
 
 const app = express();
@@ -10,12 +11,17 @@ const port = process.env.PORT || 3000;
 app.use(cors());
 app.use(express.json());
 
-// redirect root to manifest
+// serve raw manifest
 app.get("/.well-known/ai-plugin.json", (_, res) => {
   res.json(pluginData);
 });
-app.get("/", (_req, res) => res.redirect("/.well-known/ai-plugin.json"));
 
+// Custom Swagger HTML Loader
+app.use("/docs", swaggerHandler);
+// make the home page show docs
+app.get("/", (_req, res) => res.redirect(302, "/docs"));
+
+// Tool Routes
 app.use("/api/health", healthRouter);
 
 app.get(


### PR DESCRIPTION
This took a super long time to sort out, but the main point, I think, is that Vercel is serverless and express apps are servers. In order for express to run this swagger UI route we must construct the HTML at build time so that the static HTML page (the swagger UI) is an interactive one. Not sure if this is the best solution, but its been enough digging for such a small detail that I have had enough.


I attempts several things; beginning with this

Trying this: https://github.com/swagger-api/swagger-ui/issues/8461#issuecomment-1497927943